### PR TITLE
Switching from `ts-node-dev` to `tsx` for development watcher

### DIFF
--- a/apps/express/package.json
+++ b/apps/express/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
-    "dev": "ts-node-dev --respawn src/index.ts",
+    "dev": "tsx watch --clear-screen=false src/index.ts ",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
@@ -15,7 +15,10 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.21",
-    "@types/node": "^20.11.25"
+    "@types/node": "^20.11.25",
+    "@acme/tsconfig": "workspace:*",
+    "@acme/prettier-config": "workspace:*",
+    "@acme/eslint-config": "workspace:*"
   },
   "dependencies": {
     "express": "^4.18.3",

--- a/apps/express/src/index.ts
+++ b/apps/express/src/index.ts
@@ -1,10 +1,11 @@
-import express, { Request, Response } from 'express';
+import type { Request, Response } from 'express';
+import express from 'express';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.get('/', (req: Request, res: Response) => {
-  res.send('Hello, TypeScript Express!');
+  res.send('Hello, TypeScript Expresss!');
 });
 
 app.listen(port, () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,15 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1
     devDependencies:
+      '@acme/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint
+      '@acme/prettier-config':
+        specifier: workspace:*
+        version: link:../../tooling/prettier
+      '@acme/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21


### PR DESCRIPTION
It looks like `ts-node-dev` itself was the problem. I was checking `node_modules` and it was getting installed but failing to resolve. I've seen `ts-node-dev do really weird stuff like this more than once so I always recommend using `tsx` instead.

I also just fixed up resolving for other stuff to do while I was in there. Hope it helps!